### PR TITLE
Add JSON constructors

### DIFF
--- a/src/Amido.Stacks.Application.CQRS.Events/Amido.Stacks.Application.CQRS.Events.csproj
+++ b/src/Amido.Stacks.Application.CQRS.Events/Amido.Stacks.Application.CQRS.Events.csproj
@@ -4,5 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.15"/>
+	<PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
   </ItemGroup>
 </Project>

--- a/src/Amido.Stacks.Application.CQRS.Events/CategoryCreatedEvent.cs
+++ b/src/Amido.Stacks.Application.CQRS.Events/CategoryCreatedEvent.cs
@@ -1,11 +1,21 @@
 using System;
 using Amido.Stacks.Application.CQRS.ApplicationEvents;
 using Amido.Stacks.Core.Operations;
+using Newtonsoft.Json;
 
 namespace Amido.Stacks.Application.CQRS.Events
 {
 	public class CategoryCreatedEvent : IApplicationEvent
 	{
+		[JsonConstructor]
+		public CategoryCreatedEvent(int operationCode, Guid correlationId, Guid menuId, Guid categoryId)
+		{
+			OperationCode = operationCode;
+			CorrelationId = correlationId;
+			MenuId = menuId;
+			CategoryId = categoryId;
+		}
+
 		public CategoryCreatedEvent(IOperationContext context, Guid menuId, Guid categoryId)
 		{
 			OperationCode = context.OperationCode;

--- a/src/Amido.Stacks.Application.CQRS.Events/CategoryDeletedEvent.cs
+++ b/src/Amido.Stacks.Application.CQRS.Events/CategoryDeletedEvent.cs
@@ -1,11 +1,21 @@
 using System;
 using Amido.Stacks.Application.CQRS.ApplicationEvents;
 using Amido.Stacks.Core.Operations;
+using Newtonsoft.Json;
 
 namespace Amido.Stacks.Application.CQRS.Events
 {
 	public class CategoryDeletedEvent : IApplicationEvent
 	{
+		[JsonConstructor]
+		public CategoryDeletedEvent(int operationCode, Guid correlationId, Guid menuId, Guid categoryId)
+		{
+			OperationCode = operationCode;
+			CorrelationId = correlationId;
+			MenuId = menuId;
+			CategoryId = categoryId;
+		}
+
 		public CategoryDeletedEvent(IOperationContext context, Guid menuId, Guid categoryId)
 		{
 			OperationCode = context.OperationCode;
@@ -13,7 +23,6 @@ namespace Amido.Stacks.Application.CQRS.Events
 			MenuId = menuId;
 			CategoryId = categoryId;
 		}
-
 
 		public int EventCode => (int)Enums.EventCode.CategoryDeleted;
 

--- a/src/Amido.Stacks.Application.CQRS.Events/CategoryUpdatedEvent.cs
+++ b/src/Amido.Stacks.Application.CQRS.Events/CategoryUpdatedEvent.cs
@@ -1,11 +1,21 @@
 using System;
 using Amido.Stacks.Application.CQRS.ApplicationEvents;
 using Amido.Stacks.Core.Operations;
+using Newtonsoft.Json;
 
 namespace Amido.Stacks.Application.CQRS.Events
 {
 	public class CategoryUpdatedEvent : IApplicationEvent
 	{
+		[JsonConstructor]
+		public CategoryUpdatedEvent(int operationCode, Guid correlationId, Guid menuId, Guid categoryId)
+		{
+			OperationCode = operationCode;
+			CorrelationId = correlationId;
+			MenuId = menuId;
+			CategoryId = categoryId;
+		}
+
 		public CategoryUpdatedEvent(IOperationContext context, Guid menuId, Guid categoryId)
 		{
 			OperationCode = context.OperationCode;

--- a/src/Amido.Stacks.Application.CQRS.Events/MenuCreatedEvent.cs
+++ b/src/Amido.Stacks.Application.CQRS.Events/MenuCreatedEvent.cs
@@ -1,18 +1,26 @@
 using System;
 using Amido.Stacks.Application.CQRS.ApplicationEvents;
 using Amido.Stacks.Core.Operations;
+using Newtonsoft.Json;
 
 namespace Amido.Stacks.Application.CQRS.Events
 {
 	public class MenuCreatedEvent : IApplicationEvent
 	{
+		[JsonConstructor]
+		public MenuCreatedEvent(int operationCode, Guid correlationId, Guid menuId)
+		{
+			OperationCode = operationCode;
+			CorrelationId = correlationId;
+			MenuId = menuId;
+		}
+
 		public MenuCreatedEvent(IOperationContext context, Guid menuId)
 		{
 			OperationCode = context.OperationCode;
 			CorrelationId = context.CorrelationId;
 			MenuId = menuId;
 		}
-
 
 		public int EventCode => (int)Enums.EventCode.MenuCreated;
 

--- a/src/Amido.Stacks.Application.CQRS.Events/MenuDeletedEvent.cs
+++ b/src/Amido.Stacks.Application.CQRS.Events/MenuDeletedEvent.cs
@@ -1,11 +1,20 @@
 using System;
 using Amido.Stacks.Application.CQRS.ApplicationEvents;
 using Amido.Stacks.Core.Operations;
+using Newtonsoft.Json;
 
 namespace Amido.Stacks.Application.CQRS.Events
 {
 	public class MenuDeletedEvent : IApplicationEvent
 	{
+		[JsonConstructor]
+		public MenuDeletedEvent(int operationCode, Guid correlationId, Guid menuId)
+		{
+			OperationCode = operationCode;
+			CorrelationId = correlationId;
+			MenuId = menuId;
+		}
+
 		public MenuDeletedEvent(IOperationContext context, Guid menuId)
 		{
 			OperationCode = context.OperationCode;

--- a/src/Amido.Stacks.Application.CQRS.Events/MenuItemCreatedEvent.cs
+++ b/src/Amido.Stacks.Application.CQRS.Events/MenuItemCreatedEvent.cs
@@ -1,11 +1,22 @@
 ﻿using System;
 using Amido.Stacks.Application.CQRS.ApplicationEvents;
 using Amido.Stacks.Core.Operations;
+using Newtonsoft.Json;
 
 namespace Amido.Stacks.Application.CQRS.Events
 {
 	public class MenuItemCreatedEvent : IApplicationEvent
 	{
+		[JsonConstructor]
+		public MenuItemCreatedEvent(int operationCode, Guid correlationId, Guid menuId, Guid categoryId, Guid menuItemId)
+		{
+			OperationCode = operationCode;
+			CorrelationId = correlationId;
+			MenuId = menuId;
+			CategoryId = categoryId;
+			MenuItemId = menuItemId;
+		}
+
 		public MenuItemCreatedEvent(IOperationContext context, Guid menuId, Guid categoryId, Guid menuItemId)
 		{
 			OperationCode = context.OperationCode;

--- a/src/Amido.Stacks.Application.CQRS.Events/MenuItemDeletedEvent.cs
+++ b/src/Amido.Stacks.Application.CQRS.Events/MenuItemDeletedEvent.cs
@@ -1,11 +1,22 @@
 using System;
 using Amido.Stacks.Application.CQRS.ApplicationEvents;
 using Amido.Stacks.Core.Operations;
+using Newtonsoft.Json;
 
 namespace Amido.Stacks.Application.CQRS.Events
 {
 	public class MenuItemDeletedEvent : IApplicationEvent
 	{
+		[JsonConstructor]
+		public MenuItemDeletedEvent(int operationCode, Guid correlationId, Guid menuId, Guid categoryId, Guid menuItemId)
+		{
+			OperationCode = operationCode;
+			CorrelationId = correlationId;
+			MenuId = menuId;
+			CategoryId = categoryId;
+			MenuItemId = menuItemId;
+		}
+
 		public MenuItemDeletedEvent(IOperationContext context, Guid menuId, Guid categoryId, Guid menuItemId)
 		{
 			OperationCode = context.OperationCode;

--- a/src/Amido.Stacks.Application.CQRS.Events/MenuItemUpdatedEvent.cs
+++ b/src/Amido.Stacks.Application.CQRS.Events/MenuItemUpdatedEvent.cs
@@ -1,11 +1,22 @@
 using System;
 using Amido.Stacks.Application.CQRS.ApplicationEvents;
 using Amido.Stacks.Core.Operations;
+using Newtonsoft.Json;
 
 namespace Amido.Stacks.Application.CQRS.Events
 {
 	public class MenuItemUpdatedEvent : IApplicationEvent
 	{
+		[JsonConstructor]
+		public MenuItemUpdatedEvent(int operationCode, Guid correlationId, Guid menuId, Guid categoryId, Guid menuItemId)
+		{
+			OperationCode = operationCode;
+			CorrelationId = correlationId;
+			MenuId = menuId;
+			CategoryId = categoryId;
+			MenuItemId = menuItemId;
+		}
+
 		public MenuItemUpdatedEvent(IOperationContext context, Guid menuId, Guid categoryId, Guid menuItemId)
 		{
 			OperationCode = context.OperationCode;

--- a/src/Amido.Stacks.Application.CQRS.Events/MenuUpdatedEvent.cs
+++ b/src/Amido.Stacks.Application.CQRS.Events/MenuUpdatedEvent.cs
@@ -1,11 +1,20 @@
 using System;
 using Amido.Stacks.Application.CQRS.ApplicationEvents;
 using Amido.Stacks.Core.Operations;
+using Newtonsoft.Json;
 
 namespace Amido.Stacks.Application.CQRS.Events
 {
 	public class MenuUpdatedEvent : IApplicationEvent
 	{
+		[JsonConstructor]
+		public MenuUpdatedEvent(int operationCode, Guid correlationId, Guid menuId)
+		{
+			OperationCode = operationCode;
+			CorrelationId = correlationId;
+			MenuId = menuId;
+		}
+
 		public MenuUpdatedEvent(IOperationContext context, Guid menuId)
 		{
 			OperationCode = context.OperationCode;


### PR DESCRIPTION
#### 📲 What

Add JSON constructors needed for deserialization

#### 🤔 Why

Because without them we can't deserialize the event payload