### PR TITLE
Add CosmosDbChangeFeedEvent to package

### DIFF
--- a/src/Amido.Stacks.Application.CQRS.Events/CosmosDbChangeFeedEvent.cs
+++ b/src/Amido.Stacks.Application.CQRS.Events/CosmosDbChangeFeedEvent.cs
@@ -1,0 +1,37 @@
+using System;
+using Amido.Stacks.Application.CQRS.ApplicationEvents;
+using Amido.Stacks.Core.Operations;
+using Newtonsoft.Json;
+
+namespace Amido.Stacks.Application.CQRS.Events
+{
+	public class CosmosDbChangeFeedEvent : IApplicationEvent
+	{
+		[JsonConstructor]
+		public CosmosDbChangeFeedEvent(int operationCode, Guid correlationId, Guid entityId, string eTag)
+		{
+			OperationCode = operationCode;
+			CorrelationId = correlationId;
+			EntityId = entityId;
+			ETag = eTag;
+		}
+
+		public CosmosDbChangeFeedEvent(IOperationContext context, Guid entityId, string eTag)
+		{
+			OperationCode = context.OperationCode;
+			CorrelationId = context.CorrelationId;
+			EntityId = entityId;
+			ETag = eTag;
+		}
+
+		public int EventCode => (int)Enums.EventCode.EntityUpdated;
+
+		public int OperationCode { get; private set; }
+
+		public Guid CorrelationId { get; private set; }
+
+		public Guid EntityId { get; private set; }
+
+		public string ETag { get; private set; }
+	}
+}

--- a/src/Amido.Stacks.Application.CQRS.Events/Enums/EventCode.cs
+++ b/src/Amido.Stacks.Application.CQRS.Events/Enums/EventCode.cs
@@ -15,6 +15,9 @@ namespace Amido.Stacks.Application.CQRS.Events.Enums
 		// Items Operations
 		MenuItemCreated = 301,
 		MenuItemUpdated = 302,
-		MenuItemDeleted = 303
+		MenuItemDeleted = 303,
+
+		// CosmosDB change feed operations
+		EntityUpdated = 999
 	}
 }


### PR DESCRIPTION
3378 - Add CosmosDbChangeFeedEvent to package

#### 📲 What

A new event type that will be published by the CosmosDb change feed worker and consumed by the background worker

#### 🤔 Why

We want to clean up our code and put this event in the package so it could be reused.